### PR TITLE
Add a new HTTPS site with valid DANE

### DIFF
--- a/dane-test-sites.json
+++ b/dane-test-sites.json
@@ -46,5 +46,10 @@
     "name": "denic.de",
     "type": "SMTP",
     "expected_status": "OK"
+  },
+  {
+    "name": "ip.o2g.fr",
+    "type": "HTTP",
+    "expected_status": "OK"
   }
 ]


### PR DESCRIPTION
In case it's needed, there is also ipv4.o2g.fr available on IPv4 only and ipv6.o2g.fr on IPv6 only.
This URL has interesting "features": EC and RSA certificates, with or without SNI.